### PR TITLE
Added the ability to separately disable worldmap and minimap

### DIFF
--- a/src/main/java/info/infinf/xaeroTracker/XaeroTracker.java
+++ b/src/main/java/info/infinf/xaeroTracker/XaeroTracker.java
@@ -372,8 +372,12 @@ public final class XaeroTracker extends JavaPlugin implements Listener {
      * @param msg
      */
     public void send(Player pl, byte[] msg) {
-        pl.sendPluginMessage(this, MINIMAP_PACKET_ID, msg);
-        pl.sendPluginMessage(this, WORLD_MAP_PACKET_ID, msg);
+        if (getConfig().getBoolean("sync-minimap")) {
+            pl.sendPluginMessage(this, MINIMAP_PACKET_ID, msg);
+        }
+        if (getConfig().getBoolean("sync-worldmap")) {
+            pl.sendPluginMessage(this, WORLD_MAP_PACKET_ID, msg);
+        }
     }
 
     public void sendModderBothChannels(Player pl, @NotNull PlayerData data, byte[] msg) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,6 @@
 should-send-level-id: true
 sync-cooldown: 250
 only-sync-same-world: false
+
+sync-worldmap: true
+sync-minimap: true


### PR DESCRIPTION
Added 2 new configuration parameters.

`sync-worldmap: true`
`sync-minimap: true`

They are responsible for separately disabling worldmap and minimap synchronization.
This is necessary to hide the display of players through blocks, while keeping the display on the large map. A similar setting can also be implemented on the client side, but for that, each player would need to disable the display for themselves.

<img width="748" height="225" alt="image" src="https://github.com/user-attachments/assets/a55f638c-c9f5-4410-a5f3-d71fe8a39424" />
